### PR TITLE
LEN-5531: Update Github Action dependencies

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -5,7 +5,7 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - run: npm install
       - run: npm run lint
       - run: npm run test


### PR DESCRIPTION
This PR upgrades `actions/checkout` to the latest v4 version, which uses Node 20, as older versions of Node are no longer supported, and subsequent versions of `checkout` bring many bug fixes and other improvements.